### PR TITLE
fix(search_academic): resolve pyright linter errors

### DIFF
--- a/openhands-tools/openhands/tools/search_academic/definition.py
+++ b/openhands-tools/openhands/tools/search_academic/definition.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import Field
 
+
 if TYPE_CHECKING:
     from openhands.sdk.conversation.state import ConversationState
 
@@ -14,11 +15,8 @@ from openhands.sdk.tool import (
     Observation,
     ToolAnnotations,
     ToolDefinition,
-    ToolExecutor,
     register_tool,
 )
-
-from openhands.tools.search_academic.models import SearchResponse
 
 
 TOOL_DESCRIPTION = """Search academic papers from multiple sources.
@@ -28,7 +26,8 @@ This tool searches for academic papers using various search engines including:
 - arXiv (free, preprints in computer science and related fields)
 - Serper (requires API key for Google Search)
 
-Returns structured search results with title, URL, authors, publication date, and relevance score.
+Returns structured search results with title, URL, authors, publication date,
+and relevance score.
 """
 
 
@@ -43,11 +42,18 @@ class SearchAction(Action):
 
     query: str = Field(
         ...,
-        description="The search query string. For example: 'machine learning', 'deep learning transformers'",
+        description=(
+            "The search query string."
+            " For example: 'machine learning', 'deep learning transformers'"
+        ),
     )
     engines: list[str] = Field(
         default_factory=lambda: ["scholar", "arxiv"],
-        description="List of search engines to use. Available: 'scholar' (Semantic Scholar), 'arxiv' (arXiv), 'serper' (requires API key)",
+        description=(
+            "List of search engines to use."
+            " Available: 'scholar' (Semantic Scholar),"
+            " 'arxiv' (arXiv), 'serper' (requires API key)"
+        ),
     )
     max_results: int = Field(
         default=10,
@@ -96,7 +102,9 @@ class SearchObservation(Observation):
             result_text += f"   URL: {result.get('url', 'N/A')}\n"
             result_text += f"   Source: {result.get('source', 'N/A')}\n"
             if result.get("authors"):
-                result_text += f"   Authors: {', '.join(result['authors'])}\n"
+                authors = result["authors"]
+                if isinstance(authors, list):
+                    result_text += f"   Authors: {', '.join(authors)}\n"
             result_text += f"   Relevance: {result.get('relevance_score', 0.5)}\n\n"
 
         return [TextContent(text=result_text)]
@@ -110,7 +118,7 @@ class SearchAcademicTool(ToolDefinition[SearchAction, SearchObservation]):
     @classmethod
     def create(
         cls,
-        conv_state: "ConversationState",
+        _conv_state: "ConversationState",
         **params: dict,
     ) -> Sequence["SearchAcademicTool"]:
         """Create tool instance.
@@ -124,7 +132,7 @@ class SearchAcademicTool(ToolDefinition[SearchAction, SearchObservation]):
         """
         from openhands.tools.search_academic.impl import SearchExecutor
 
-        executor = SearchExecutor(**params)
+        executor = SearchExecutor(**params)  # pyright: ignore[reportArgumentType]
 
         return [
             cls(

--- a/openhands-tools/openhands/tools/search_academic/engines/base.py
+++ b/openhands-tools/openhands/tools/search_academic/engines/base.py
@@ -2,11 +2,12 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, ClassVar
 
 import httpx
 
 from openhands.tools.search_academic.models import SearchResponse, SearchResult
+
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class BaseSearchEngine(ABC):
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         timeout: int = 30,
     ) -> None:
         """Initialize search engine.
@@ -43,11 +44,11 @@ class BaseSearchEngine(ABC):
 
     @staticmethod
     @abstractmethod
-    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse raw API response to SearchResult objects.
 
         Args:
-            raw_response: Raw response from API
+            raw_response: Raw response from API (XML string or JSON dict)
 
         Returns:
             List of SearchResult objects
@@ -57,8 +58,8 @@ class BaseSearchEngine(ABC):
     async def _fetch_with_retry(
         self,
         url: str,
-        headers: Optional[dict[str, str]] = None,
-        params: Optional[dict[str, Any]] = None,
+        headers: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
         max_retries: int = 3,
     ) -> dict[str, Any]:
         """Fetch data from URL with retry logic.
@@ -87,8 +88,9 @@ class BaseSearchEngine(ABC):
             except Exception as e:
                 last_exception = e
                 logger.warning(
-                    f"Fetch attempt {attempt + 1} failed: {e}. "
-                    f"Retrying..." if attempt < max_retries - 1 else "Giving up."
+                    f"Fetch attempt {attempt + 1} failed: {e}. Retrying..."
+                    if attempt < max_retries - 1
+                    else "Giving up."
                 )
 
         if last_exception:
@@ -101,7 +103,7 @@ class SerperSearchEngine(BaseSearchEngine):
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         timeout: int = 30,
     ) -> None:
         """Initialize Serper search engine.
@@ -165,7 +167,7 @@ class SerperSearchEngine(BaseSearchEngine):
             )
 
     @staticmethod
-    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse Serper API response.
 
         Args:
@@ -174,6 +176,8 @@ class SerperSearchEngine(BaseSearchEngine):
         Returns:
             List of SearchResult objects
         """
+        if not isinstance(raw_response, dict):
+            return []
         results = []
         for item in raw_response.get("organic", []):
             result = SearchResult(
@@ -192,13 +196,14 @@ class ScholarSearchEngine(BaseSearchEngine):
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         timeout: int = 30,
     ) -> None:
         """Initialize Semantic Scholar search engine.
 
         Args:
-            api_key: API key for Semantic Scholar. If not provided, searches will return empty.
+            api_key: API key for Semantic Scholar.
+                If not provided, searches will return empty.
             timeout: Request timeout in seconds
         """
         super().__init__(api_key=api_key, timeout=timeout)
@@ -262,7 +267,7 @@ class ScholarSearchEngine(BaseSearchEngine):
             )
 
     @staticmethod
-    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse Semantic Scholar API response.
 
         Args:
@@ -271,6 +276,8 @@ class ScholarSearchEngine(BaseSearchEngine):
         Returns:
             List of SearchResult objects
         """
+        if not isinstance(raw_response, dict):
+            return []
         results = []
         for item in raw_response.get("data", []):
             authors = [a.get("name", "") for a in item.get("authors", [])]
@@ -288,7 +295,7 @@ class ScholarSearchEngine(BaseSearchEngine):
 class ArxivSearchEngine(BaseSearchEngine):
     """arXiv search engine (free)."""
 
-    NS = {
+    NS: ClassVar[dict[str, str]] = {
         "atom": "http://www.w3.org/2005/Atom",
         "arxiv": "http://arxiv.org/schemas/atom",
     }
@@ -321,7 +328,9 @@ class ArxivSearchEngine(BaseSearchEngine):
             }
 
             # Get raw XML response
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True
+            ) as client:
                 response = await client.get(self.api_endpoint, params=params)
                 response.raise_for_status()
                 xml_text = response.text
@@ -346,21 +355,23 @@ class ArxivSearchEngine(BaseSearchEngine):
             )
 
     @staticmethod
-    def parse_results(xml_response: str) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse arXiv API XML response.
 
         Args:
-            xml_response: Raw XML response from arXiv API
+            raw_response: Raw XML response from arXiv API
 
         Returns:
             List of SearchResult objects
         """
+        if not isinstance(raw_response, str):
+            return []
         import xml.etree.ElementTree as ET
         from datetime import datetime
 
         results = []
         try:
-            root = ET.fromstring(xml_response)
+            root = ET.fromstring(raw_response)
             entries = root.findall("atom:entry", ArxivSearchEngine.NS)
 
             for entry in entries:
@@ -369,10 +380,14 @@ class ArxivSearchEngine(BaseSearchEngine):
                 published = entry.find("atom:published", ArxivSearchEngine.NS)
                 link = entry.find("atom:link[@title='pdf']", ArxivSearchEngine.NS)
                 if link is None:
-                    link = entry.find("atom:link[@rel='alternate']", ArxivSearchEngine.NS)
+                    link = entry.find(
+                        "atom:link[@rel='alternate']", ArxivSearchEngine.NS
+                    )
 
                 authors = []
-                for author in entry.findall("atom:author/atom:name", ArxivSearchEngine.NS):
+                for author in entry.findall(
+                    "atom:author/atom:name", ArxivSearchEngine.NS
+                ):
                     if author.text:
                         authors.append(author.text)
 
@@ -385,10 +400,14 @@ class ArxivSearchEngine(BaseSearchEngine):
                         pass
 
                 result = SearchResult(
-                    title=title.text.strip() if title is not None and title.text else "",
+                    title=title.text.strip()
+                    if title is not None and title.text
+                    else "",
                     url=link.get("href", "") if link is not None else "",
                     source="arxiv",
-                    snippet=summary.text.strip()[:500] if summary is not None and summary.text else None,
+                    snippet=summary.text.strip()[:500]
+                    if summary is not None and summary.text
+                    else None,
                     authors=authors,
                     published_date=parsed_date,
                     relevance_score=0.8,


### PR DESCRIPTION
## Summary

Fix 5 pyright type errors in `search_academic` module and 6 ruff style issues. All pre-commit hooks pass.

Closes #11

## Changes

### definition.py
- Fix `join(authors)` type error: extract variable + `isinstance(list)` guard
- Suppress `SearchExecutor(**params)` dynamic dispatch type check
- Shorten long lines (E501), rename unused `conv_state` → `_conv_state`

### engines/base.py
- Unify `parse_results` signature across base + 3 subclasses to `str | dict[str, Any]`
- Rename `xml_response` → `raw_response` for consistency with base class
- Add `ClassVar` annotation on `ArxivSearchEngine.NS`
- Shorten long line (E501)

## Test plan

- [x] 14/14 tests pass
- [x] pyright: 0 errors
- [x] ruff: 0 errors
- [x] All 7 pre-commit hooks pass