### PR TITLE
fix(search_academic): populate snippet and pdf_url in search results

### DIFF
--- a/openhands-tools/openhands/tools/search_academic/engines/base.py
+++ b/openhands-tools/openhands/tools/search_academic/engines/base.py
@@ -237,7 +237,10 @@ class ScholarSearchEngine(BaseSearchEngine):
             params = {
                 "query": query,
                 "limit": max_results,
-                "fields": "paperId,title,url,authors,publicationDate,abstract",
+                "fields": (
+                    "paperId,title,url,authors,publicationDate,"
+                    "abstract,openAccessPdf,isOpenAccess"
+                ),
             }
 
             headers = {"x-api-key": self.api_key}
@@ -281,11 +284,14 @@ class ScholarSearchEngine(BaseSearchEngine):
         results = []
         for item in raw_response.get("data", []):
             authors = [a.get("name", "") for a in item.get("authors", [])]
+            open_access = item.get("openAccessPdf") or {}
             result = SearchResult(
                 title=item.get("title", ""),
                 url=f"https://semanticscholar.org/paper/{item.get('paperId', '')}",
                 source="scholar",
+                snippet=item.get("abstract"),
                 authors=authors,
+                pdf_url=open_access.get("url"),
                 relevance_score=0.85,
             )
             results.append(result)
@@ -378,11 +384,10 @@ class ArxivSearchEngine(BaseSearchEngine):
                 title = entry.find("atom:title", ArxivSearchEngine.NS)
                 summary = entry.find("atom:summary", ArxivSearchEngine.NS)
                 published = entry.find("atom:published", ArxivSearchEngine.NS)
-                link = entry.find("atom:link[@title='pdf']", ArxivSearchEngine.NS)
-                if link is None:
-                    link = entry.find(
-                        "atom:link[@rel='alternate']", ArxivSearchEngine.NS
-                    )
+                pdf_link = entry.find("atom:link[@title='pdf']", ArxivSearchEngine.NS)
+                abs_link = entry.find(
+                    "atom:link[@rel='alternate']", ArxivSearchEngine.NS
+                )
 
                 authors = []
                 for author in entry.findall(
@@ -399,15 +404,18 @@ class ArxivSearchEngine(BaseSearchEngine):
                     except ValueError:
                         pass
 
+                pdf_url = pdf_link.get("href", "") if pdf_link is not None else ""
+                abs_url = abs_link.get("href", "") if abs_link is not None else ""
                 result = SearchResult(
                     title=title.text.strip()
                     if title is not None and title.text
                     else "",
-                    url=link.get("href", "") if link is not None else "",
+                    url=abs_url,
                     source="arxiv",
                     snippet=summary.text.strip()[:500]
                     if summary is not None and summary.text
                     else None,
+                    pdf_url=pdf_url,
                     authors=authors,
                     published_date=parsed_date,
                     relevance_score=0.8,

--- a/openhands-tools/openhands/tools/search_academic/models.py
+++ b/openhands-tools/openhands/tools/search_academic/models.py
@@ -1,7 +1,6 @@
 """Data models for academic search tools."""
 
 from datetime import date
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -15,15 +14,19 @@ class SearchResult(BaseModel):
         ...,
         description="Search engine source (serper, scholar, arxiv, pubmed, openalex)",
     )
-    snippet: Optional[str] = Field(
+    snippet: str | None = Field(
         default=None,
         description="Short snippet or abstract",
+    )
+    pdf_url: str | None = Field(
+        default=None,
+        description="Direct PDF download link when available (e.g. openAccessPdf.url)",
     )
     authors: list[str] = Field(
         default_factory=list,
         description="List of author names",
     )
-    published_date: Optional[date] = Field(
+    published_date: date | None = Field(
         default=None,
         description="Publication date",
     )

--- a/tests/tools/search_academic/test_search_engines.py
+++ b/tests/tools/search_academic/test_search_engines.py
@@ -1,28 +1,22 @@
-"""Integration tests for academic search engines.
-
-These tests verify that each search engine can successfully
-connect to and retrieve results from its respective API.
-
-Run with: pytest tests/tools/search_academic/test_search_engines.py -v
-"""
+"""Integration tests for academic search engines."""
 
 import os
 import sys
 
-# Add the openhands-tools package to path
-_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-sys.path.insert(0, os.path.join(_repo_root, "openhands-tools"))
-
 import pytest
 
-from openhands.tools.search_academic.engines import (
-    ScholarSearchEngine,
+
+_repo_root = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+)
+sys.path.insert(0, os.path.join(_repo_root, "openhands-tools"))
+
+from openhands.tools.search_academic.engines import (  # noqa: E402
     ArxivSearchEngine,
+    ScholarSearchEngine,
     SerperSearchEngine,
 )
-
-
-from tests.tools.search_academic.conftest import require_env
+from tests.tools.search_academic.conftest import require_env  # noqa: E402
 
 
 class TestScholarSearchEngine:
@@ -30,33 +24,30 @@ class TestScholarSearchEngine:
 
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
-        """Test that Scholar search returns non-empty results with API key."""
         api_key = require_env("SEMANTIC_SCHOLAR_API_KEY")
-
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)
 
         assert response.engine == "scholar"
-        assert response.total_found > 0, "Semantic Scholar API should return results"
+        assert response.total_found > 0
         assert len(response.results) > 0
-        print(f"\n✓ Scholar returned {len(response.results)} results")
 
     @pytest.mark.asyncio
     async def test_search_result_structure(self):
-        """Test that search results have required fields."""
+        """Search results must have title, url, snippet (abstract), and pdf_url."""
         api_key = require_env("SEMANTIC_SCHOLAR_API_KEY")
-
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("transformer attention", max_results=3)
 
-        assert response.total_found > 0, "Semantic Scholar API should return results"
-        assert len(response.results) > 0
+        assert response.total_found > 0
         result = response.results[0]
-
         assert result.title
         assert result.url
         assert result.source == "scholar"
-        print(f"\n✓ Result structure valid: {result.title[:50]}...")
+        assert result.snippet and len(result.snippet) > 50, (
+            f"Expected snippet to include abstract, got: {result.snippet!r}"
+        )
+        assert hasattr(result, "pdf_url")
 
 
 class TestArxivSearchEngine:
@@ -64,30 +55,30 @@ class TestArxivSearchEngine:
 
     @pytest.mark.asyncio
     async def test_search_returns_results(self):
-        """Test that arXiv search returns non-empty results."""
         engine = ArxivSearchEngine(timeout=30)
         response = await engine.search("machine learning", max_results=5)
 
         assert response.engine == "arxiv"
-        assert response.total_found > 0, "arXiv API should return results"
+        assert response.total_found > 0
         assert len(response.results) > 0
-        print(f"\n✓ ArXiv search completed, total found: {response.total_found}")
-        print(f"  Results count: {len(response.results)}")
 
     @pytest.mark.asyncio
     async def test_search_result_structure(self):
-        """Test that search results have required fields."""
+        """Search results must have title, url (abs page), snippet, and pdf_url."""
         engine = ArxivSearchEngine(timeout=30)
         response = await engine.search("neural networks", max_results=3)
 
-        assert response.total_found > 0, "arXiv API should return results"
-        assert len(response.results) > 0
+        assert response.total_found > 0
         result = response.results[0]
         assert result.title
-        assert result.url
         assert result.source == "arxiv"
-        print(f"\n✓ ArXiv returned {len(response.results)} parsed results")
-        print(f"  First result: {result.title[:50]}...")
+        assert result.snippet, "Expected non-empty snippet (arXiv summary)"
+        assert result.url and "arxiv.org/abs/" in result.url, (
+            f"Expected abs page URL, got: {result.url!r}"
+        )
+        assert result.pdf_url and "arxiv.org/pdf/" in result.pdf_url, (
+            f"Expected PDF URL, got: {result.pdf_url!r}"
+        )
 
 
 class TestSerperSearchEngine:
@@ -95,16 +86,13 @@ class TestSerperSearchEngine:
 
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
-        """Test Serper search with valid API key."""
         api_key = require_env("SERPER_API_KEY")
-
         engine = SerperSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)
 
         assert response.engine == "serper"
-        assert response.total_found > 0, "Serper API should return results with valid API key"
+        assert response.total_found > 0
         assert len(response.results) > 0
-        print(f"\n✓ Serper returned {len(response.results)} results")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **ScholarSearchEngine**: populate `snippet` from `abstract` field and `pdf_url` from `openAccessPdf.url`
- **ArxivSearchEngine**: separate `url` (abs page) from `pdf_url` (PDF link) — previously both fields used the PDF URL
- **SearchResult model**: add `pdf_url` field for direct PDF download link
- **Tests**: updated to verify snippet, url (abs vs pdf), and pdf_url in search results

## Why
- Scholar search was not returning abstracts in results despite requesting them via API
- arXiv `url` was pointing to PDF binary, which is not suitable for web content extraction
- Semantic Scholar landing pages are JS SPAs (HTTP 202) and cannot be scraped — downstream consumers need to distinguish between fetchable abs pages and PDF links

## Test plan
- [x] SDK unit tests pass (8/8)
- [x] Scholar integration test passes
- [x] Serper integration test passes
- [ ] arXiv integration tests (currently hit HTTP 429 rate limit from API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)